### PR TITLE
Remove `itertor_concept`

### DIFF
--- a/for_code_diff/b_tree/baseline/b_tree.hpp
+++ b/for_code_diff/b_tree/baseline/b_tree.hpp
@@ -74,7 +74,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -88,7 +87,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/dfs/b_tree.hpp
+++ b/for_code_diff/b_tree/dfs/b_tree.hpp
@@ -74,7 +74,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -88,7 +87,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/hint/b_tree.hpp
+++ b/for_code_diff/b_tree/hint/b_tree.hpp
@@ -74,7 +74,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -88,7 +87,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/local/b_tree.hpp
+++ b/for_code_diff/b_tree/local/b_tree.hpp
@@ -75,7 +75,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -89,7 +88,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/local_dfs/b_tree.hpp
+++ b/for_code_diff/b_tree/local_dfs/b_tree.hpp
@@ -75,7 +75,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -89,7 +88,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/local_vEB/b_tree.hpp
+++ b/for_code_diff/b_tree/local_vEB/b_tree.hpp
@@ -75,7 +75,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -89,7 +88,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/b_tree/vEB/b_tree.hpp
+++ b/for_code_diff/b_tree/vEB/b_tree.hpp
@@ -74,7 +74,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         const value_type& operator*() const noexcept { return *Base::get(); }
@@ -88,7 +87,6 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
         value_type& operator*() const noexcept { return *Base::get(); }

--- a/for_code_diff/skip_list/baseline/skiplist.hpp
+++ b/for_code_diff/skip_list/baseline/skiplist.hpp
@@ -100,7 +100,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     using level_type = typename Node::level_type;
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -125,7 +124,6 @@ public:
     static_assert(std::bidirectional_iterator<iterator>);
     using reverse_iterator = std::reverse_iterator<iterator>;
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/for_code_diff/skip_list/hint/skiplist.hpp
+++ b/for_code_diff/skip_list/hint/skiplist.hpp
@@ -100,7 +100,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     using level_type = typename Node::level_type;
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -125,7 +124,6 @@ public:
     static_assert(std::bidirectional_iterator<iterator>);
     using reverse_iterator = std::reverse_iterator<iterator>;
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/for_code_diff/skip_list/local/skiplist.hpp
+++ b/for_code_diff/skip_list/local/skiplist.hpp
@@ -101,7 +101,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     using level_type = typename Node::level_type;
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -126,7 +125,6 @@ public:
     static_assert(std::bidirectional_iterator<iterator>);
     using reverse_iterator = std::reverse_iterator<iterator>;
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/for_code_diff/skip_list/local_page/skiplist.hpp
+++ b/for_code_diff/skip_list/local_page/skiplist.hpp
@@ -101,7 +101,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     using level_type = typename Node::level_type;
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -126,7 +125,6 @@ public:
     static_assert(std::bidirectional_iterator<iterator>);
     using reverse_iterator = std::reverse_iterator<iterator>;
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/for_code_diff/skip_list/page/skiplist.hpp
+++ b/for_code_diff/skip_list/page/skiplist.hpp
@@ -100,7 +100,6 @@ public:
     using size_type = std::make_unsigned_t<difference_type>;
     using level_type = typename Node::level_type;
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -125,7 +124,6 @@ public:
     static_assert(std::bidirectional_iterator<iterator>);
     using reverse_iterator = std::reverse_iterator<iterator>;
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/include/far_memory_container/baseline/b_tree.hpp
+++ b/include/far_memory_container/baseline/b_tree.hpp
@@ -99,7 +99,6 @@ public:
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 
@@ -117,7 +116,6 @@ public:
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 

--- a/include/far_memory_container/baseline/skiplist.hpp
+++ b/include/far_memory_container/baseline/skiplist.hpp
@@ -137,8 +137,6 @@ public:
     using level_type = typename Node::level_type;
 
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -170,8 +168,6 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
 
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/include/far_memory_container/blocked/b_tree.hpp
+++ b/include/far_memory_container/blocked/b_tree.hpp
@@ -102,7 +102,6 @@ public:
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 
@@ -120,7 +119,6 @@ public:
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 

--- a/include/far_memory_container/blocked/skiplist.hpp
+++ b/include/far_memory_container/blocked/skiplist.hpp
@@ -137,8 +137,6 @@ public:
     using level_type = typename Node::level_type;
 
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -170,8 +168,6 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
 
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;

--- a/include/far_memory_container/page_aware/b_tree.hpp
+++ b/include/far_memory_container/page_aware/b_tree.hpp
@@ -99,7 +99,6 @@ public:
     struct const_iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 
@@ -117,7 +116,6 @@ public:
     struct iterator : BTreeIterBase<Node> {
         using Base = BTreeIterBase<Node>;
 
-        using itertor_concept = std::bidirectional_iterator_tag;
         using difference_type = BTreeMap::difference_type;
         using value_type = typename Base::value_type;
 

--- a/include/far_memory_container/page_aware/skiplist.hpp
+++ b/include/far_memory_container/page_aware/skiplist.hpp
@@ -137,8 +137,6 @@ public:
     using level_type = typename Node::level_type;
 
     struct iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;
@@ -170,8 +168,6 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
 
     struct const_iterator : SkiplistIteratorBase<Node> {
-        using itertor_concept = std::bidirectional_iterator_tag;
-
     private:
         using Base = SkiplistIteratorBase<Node>;
         using NodePtr = typename Base::NodePtr;


### PR DESCRIPTION
`itertor_concept` is a mis-spelling of `iterator_concept`. The standard library mechanisms don't detect such a member type.

Also, these iterators are already `static_assert`'d to be `bidirectional_iterator`, so even if we correctly spell `iterator_concept`, the member type will be effectless.

Fixes #1.